### PR TITLE
✨ Show previous roast summary when roasting same bean (Issue #5)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,8 @@
 # CafeMaestro Copilot Guidelines
 
 ## Project Overview
-CafeMaestro is a cross-platform coffee roasting companion app built with .NET MAUI for .NET 9.
+CafeMaestro is a cross-platform coffee roasting companion app built with .NET MAUI for .NET 9.  
+GitHub repository: [CafeMaestro](https://github.com/sasler/CafeMaestro)
 
 ## Architecture
 - Follow MVVM pattern with dependency injection.
@@ -39,6 +40,17 @@ CafeMaestro is a cross-platform coffee roasting companion app built with .NET MA
 - Use JSON for data storage via `AppDataService`.
 - Store user preferences using `PreferencesService`.
 - Implement validation and fallback mechanisms for read/write failures.
+
+## Git Workflow
+- Whenever starting work on a **GitHub issue**, create a **new Git branch** specific to that issue.
+  - Branch naming convention: `issue-<number>-<short-description>` (e.g., `issue-42-fix-ui-layout`).
+- **Do not create a commit until satisfied with the changes.** Ensure the code is stable, follows project guidelines, and is reviewed if needed.
+- For **commit messages and pull requests**, use [Gitmoji](https://gitmoji.dev/) for clarity and consistency.  
+  - Example: `✨ Add new feature for roast tracking`
+  - Helps visually categorize changes and improves commit readability.
+- When working in **Agent mode**, check if there are **any outstanding issues or problems** before completing a task.
+  - Address errors, warnings, or inconsistencies before finalizing the work.
+- Ensure commits are meaningful and describe the changes clearly.
 
 ## Best Practices
 - Follow **async/await** principles for efficient async operations.

--- a/CafeMaestro/RoastPage.xaml
+++ b/CafeMaestro/RoastPage.xaml
@@ -284,11 +284,36 @@
                 <Picker x:Name="BeanPicker"
                         Title="Coffee:"
                         TextColor="{DynamicResource PrimaryTextColor}"
-                        BackgroundColor="{DynamicResource PickerBackgroundColor}">
+                        BackgroundColor="{DynamicResource PickerBackgroundColor}"
+                        SelectedIndexChanged="BeanPicker_SelectedIndexChanged">
                     <Picker.Items>
                         <x:String>Loading beans...</x:String>
                     </Picker.Items>
                 </Picker>
+                
+                <!-- Previous Roast Info Section -->
+                <Border x:Name="PreviousRoastInfoSection" 
+                       IsVisible="false" 
+                       Margin="0,5,0,10" 
+                       Padding="10" 
+                       BackgroundColor="{AppThemeBinding Light=#f0f0f0, Dark=#303030}"
+                       Stroke="{AppThemeBinding Light=#dddddd, Dark=#444444}"
+                       StrokeShape="RoundRectangle 8">
+                    <VerticalStackLayout>
+                        <Label Text="Previous Roast" 
+                               FontAttributes="Bold" 
+                               TextColor="{StaticResource PrimaryColor}" 
+                               Margin="0,0,0,5"/>
+                        <Label x:Name="PreviousRoastSummaryLabel" 
+                               Text="" 
+                               FontSize="14" 
+                               LineBreakMode="WordWrap" />
+                        <Label x:Name="PreviousRoastDetailsLabel" 
+                               Text="" 
+                               FontSize="14" 
+                               LineBreakMode="WordWrap" />
+                    </VerticalStackLayout>
+                </Border>
 
                 <!-- Temperature -->
                 <Label Text="Roasting Temperature (°C):"

--- a/CafeMaestro/Services/RoastDataService.cs
+++ b/CafeMaestro/Services/RoastDataService.cs
@@ -985,5 +985,42 @@ namespace CafeMaestro.Services
                 return false;
             }
         }
+
+        // Get the most recent roast for a specific bean type
+        public async Task<RoastData?> GetLastRoastForBeanTypeAsync(string beanType)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(beanType))
+                    return null;
+                
+                System.Diagnostics.Debug.WriteLine($"Looking for the most recent roast of bean type: {beanType}");
+                
+                // Load all roast logs
+                var allRoasts = await GetAllRoastsAsync();
+                
+                // Find the most recent roast with the matching bean type
+                var lastRoast = allRoasts
+                    .Where(r => r.BeanType.Equals(beanType, StringComparison.OrdinalIgnoreCase))
+                    .OrderByDescending(r => r.RoastDate)
+                    .FirstOrDefault();
+                
+                if (lastRoast != null)
+                {
+                    System.Diagnostics.Debug.WriteLine($"Found previous roast from {lastRoast.RoastDate.ToShortDateString()}: {lastRoast.Summary}");
+                }
+                else
+                {
+                    System.Diagnostics.Debug.WriteLine($"No previous roasts found for bean type: {beanType}");
+                }
+                
+                return lastRoast;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"Error finding previous roast: {ex.Message}");
+                return null;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Feature Implementation: Show Previous Roast Summary

This PR implements the feature requested in issue #5, which adds the ability to show the previous roast summary when a user selects a bean type that has been roasted before.

### Changes:
- Added `GetLastRoastForBeanTypeAsync` method to `RoastDataService`
- Added UI elements to display previous roast data in `RoastPage.xaml`
- Implemented logic to load and display previous roast data
- Added automatic prefill of temperature and batch weight from previous roast
- Improved bean selection by ordering beans by purchase date (newest first)
- Filtered out beans with zero or negative quantity

### Benefits:
- Helps maintain consistency between roasts of the same bean type
- Provides quick reference to previous roasting parameters
- Improves workflow by prefilling common values
- Enhances bean selection by focusing on newest beans

### Testing:
- Tested with multiple bean types
- Verified correct display of previous roast data
- Confirmed automatic prefilling of form fields works correctly
- Ensured bean sorting shows newest beans first

Closes #5