### PR TITLE
✨ Add ability to edit remaining quantity in bean inventory

### DIFF
--- a/CafeMaestro/BeanEditPage.xaml
+++ b/CafeMaestro/BeanEditPage.xaml
@@ -75,7 +75,13 @@
                                Keyboard="Numeric"
                                Placeholder="Enter quantity in kg"/>
 
-                        <Label Text="Price ($):"/>
+                        <!-- Add new field for Remaining Quantity -->
+                        <Label Text="Remaining Quantity (kg):"/>
+                        <Entry x:Name="RemainingQuantityEntry"
+                               Keyboard="Numeric"
+                               Placeholder="Enter remaining quantity in kg"/>
+
+                        <Label Text="Price:"/>
                         <Entry x:Name="PriceEntry"
                                Keyboard="Numeric"
                                Placeholder="Enter price"/>

--- a/CafeMaestro/BeanEditPage.xaml.cs
+++ b/CafeMaestro/BeanEditPage.xaml.cs
@@ -102,6 +102,7 @@ public partial class BeanEditPage : ContentPage
             
             PurchaseDatePicker.Date = _bean.PurchaseDate;
             QuantityEntry.Text = _bean.Quantity.ToString("F2");
+            RemainingQuantityEntry.Text = _bean.RemainingQuantity.ToString("F2");
             PriceEntry.Text = _bean.Price?.ToString("F2") ?? string.Empty;
             LinkEntry.Text = _bean.Link;
             NotesEditor.Text = _bean.Notes;
@@ -200,26 +201,27 @@ public partial class BeanEditPage : ContentPage
             return false;
         }
         
-        // Update remaining quantity if this is a new bean
-        if (_bean.Id == Guid.Empty || _bean.RemainingQuantity == 0)
-        {
-            _bean.RemainingQuantity = quantity;
-        }
-        else if (quantity < _bean.Quantity)
-        {
-            // If reducing total quantity, reduce remaining proportionally
-            double ratio = quantity / _bean.Quantity;
-            _bean.RemainingQuantity = Math.Min(_bean.RemainingQuantity, quantity) * ratio;
-        }
-        else if (quantity > _bean.Quantity)
-        {
-            // If increasing total quantity, increase remaining by the difference
-            double increase = quantity - _bean.Quantity;
-            _bean.RemainingQuantity += increase;
-        }
-        
         // Set the parsed quantity
         _bean.Quantity = quantity;
+        
+        // Validate remaining quantity
+        if (string.IsNullOrWhiteSpace(RemainingQuantityEntry.Text) || 
+            !double.TryParse(RemainingQuantityEntry.Text, out double remainingQuantity) || 
+            remainingQuantity < 0)
+        {
+            DisplayAlert("Validation Error", "Please enter a valid remaining quantity", "OK");
+            return false;
+        }
+        
+        // Validate remaining quantity doesn't exceed total quantity
+        if (remainingQuantity > quantity)
+        {
+            DisplayAlert("Validation Error", "Remaining quantity cannot exceed total quantity", "OK");
+            return false;
+        }
+        
+        // Set the parsed remaining quantity
+        _bean.RemainingQuantity = remainingQuantity;
         
         // Validate price (optional)
         if (!string.IsNullOrWhiteSpace(PriceEntry.Text))

--- a/CafeMaestro/BeanEditPage.xaml.cs
+++ b/CafeMaestro/BeanEditPage.xaml.cs
@@ -202,6 +202,9 @@ public partial class BeanEditPage : ContentPage
         }
         
         // Set the parsed quantity
+        // Note: The assignment of _bean.Quantity is placed before validating the remaining quantity.
+        // This ordering is intentional as the validation logic uses the local variable 'quantity'
+        // and does not depend on the original value of _bean.Quantity.
         _bean.Quantity = quantity;
         
         // Validate remaining quantity
@@ -214,6 +217,8 @@ public partial class BeanEditPage : ContentPage
         }
         
         // Validate remaining quantity doesn't exceed total quantity
+        // Note: Unlike previous behavior, remaining quantity is now directly controlled by user input
+        // rather than being automatically adjusted based on changes to the total quantity.
         if (remainingQuantity > quantity)
         {
             DisplayAlert("Validation Error", "Remaining quantity cannot exceed total quantity", "OK");


### PR DESCRIPTION
## Changes
This PR implements the feature requested in issue #9 to allow users to directly edit the remaining quantity of beans in the inventory.

### Implementation Details
- Added a new "Remaining Quantity (kg)" field in the Bean Edit Page
- Added proper validation to ensure remaining quantity doesn't exceed total quantity
- Updated the code to save changes to the bean data model

### Acceptance Criteria
- ✅ New "Remaining Quantity (kg)" field appears below the total quantity field
- ✅ Field is pre-populated with the current remaining quantity
- ✅ Validation prevents invalid values (negative or more than total)
- ✅ Changes are properly saved to the bean data model
- ✅ UI is consistent with existing design

Closes #9