### PR TITLE
✅ Add validation for batch weight against remaining bean quantity

### DIFF
--- a/CafeMaestro/RoastPage.xaml
+++ b/CafeMaestro/RoastPage.xaml
@@ -340,8 +340,16 @@
                            Placeholder="Enter batch weight"
                            TextColor="{DynamicResource PrimaryTextColor}"
                            BackgroundColor="{DynamicResource EntryBackgroundColor}"
-                           PlaceholderColor="{DynamicResource PlaceholderColor}"/>
+                           PlaceholderColor="{DynamicResource PlaceholderColor}"
+                           TextChanged="BatchWeightEntry_TextChanged"/>
                 </Border>
+                
+                <!-- Warning label for batch weight validation -->
+                <Label x:Name="BatchWeightWarningLabel" 
+                       IsVisible="false"
+                       Text="Insufficient beans available!" 
+                       TextColor="{StaticResource SwipeDeleteColor}" 
+                       FontAttributes="Bold"/>
 
                 <!-- Final Weight Entry -->
                 <Label Text="Final Weight (g):"

--- a/CafeMaestro/RoastPage.xaml.cs
+++ b/CafeMaestro/RoastPage.xaml.cs
@@ -486,7 +486,7 @@ public partial class RoastPage : ContentPage
     }
     
     // New method to handle batch weight validation
-    private void BatchWeightEntry_TextChanged(object sender, TextChangedEventArgs e)
+    private void BatchWeightEntry_TextChanged(object? sender, TextChangedEventArgs e)
     {
         ValidateBatchWeight();
     }
@@ -515,7 +515,7 @@ public partial class RoastPage : ContentPage
                 if (batchWeight > availableBeans)
                 {
                     // Show warning and disable timer start button
-                    BatchWeightWarningLabel.Text = $"Insufficient beans available! (only {availableBeans:F1}g remaining)";
+                    BatchWeightWarningLabel.Text = $"Insufficient beans available! (only {availableBeans:F1} g remaining)";
                     BatchWeightWarningLabel.IsVisible = true;
                     StartTimerButton.IsEnabled = false;
                     


### PR DESCRIPTION
This PR resolves #10 by adding validation for batch weight against the remaining bean quantity.

## Changes Made
1. Added batch weight validation against the selected bean's remaining quantity
2. Added a visual warning label that appears when batch weight exceeds available quantity
3. Implemented logic to disable the timer start button when validation fails
4. Added code to re-enable the timer start button when batch weight becomes valid
5. Ensured validation updates when switching between different bean types

## Implementation Details
- Added warning label in XAML to display when validation fails
- Created `ValidateBatchWeight()` method to centralize validation logic
- Updated `BatchWeightEntry_TextChanged` handler to trigger validation
- Updated `BeanPicker_SelectedIndexChanged` to validate when changing beans
- Added validation call in `OnAppearing` to ensure validation runs when the page is displayed

## Testing
The implementation has been tested with various scenarios:
- Entering valid batch weight (less than available quantity)
- Entering invalid batch weight (greater than available quantity)
- Switching between different bean types with different quantities
- Resetting the form and validating again

All validation scenarios work as expected, showing the warning and disabling the start button when appropriate.