### PR TITLE
✨ Add share functionality and flexible roast saving

### DIFF
--- a/.github/skills/implement-feature/SKILL.md
+++ b/.github/skills/implement-feature/SKILL.md
@@ -235,6 +235,8 @@ After creating the PR, GitHub Copilot will automatically review it. This can tak
 
 ## Step 13 — Address Copilot Review Comments
 
+> **This step is ATOMIC.** Do not yield, stop, or mark the task complete until ALL comments have been both addressed in code AND replied to on the PR. Partial completion (e.g., replying to some comments but not others) is NOT acceptable.
+
 For each comment/suggestion from the GitHub Copilot review:
 
 1. **Read carefully** — understand what the reviewer is flagging
@@ -244,8 +246,9 @@ For each comment/suggestion from the GitHub Copilot review:
 
 After implementing changes:
 - Run all tests and builds again (Step 5)
-- Reply to **each** inline comment explaining what you did to address it
+- Reply to **every single** inline comment explaining what you did to address it
 - If you disagreed, reply with your reasoning
+- **Verify** that no unreplied comments remain before proceeding
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,17 @@ For any feature, bug fix, or change, follow the **implement-feature** skill (`.g
 7. PR creation with gitmoji
 8. GitHub Copilot auto-review polling and follow-up
 
+> **CRITICAL — Atomic Review Cycle:** Steps 7–8 form an atomic unit of work. After receiving the GitHub Copilot auto-review, you **must** complete ALL of the following before yielding, stopping, or marking the task complete:
+>
+> 1. Read and evaluate **every** review comment
+> 2. Fix all valid issues in code
+> 3. Re-run tests and builds to verify fixes
+> 4. Commit and push the fixes
+> 5. Reply to **every single comment** on the PR explaining what you did (or why you disagree)
+> 6. Confirm no unreplied comments remain
+>
+> **Do NOT** stop partway through the review cycle. Replying to some comments but not others is unacceptable — treat the review follow-up as a single indivisible operation.
+
 ---
 
 ## Architecture
@@ -187,6 +198,8 @@ Follow **MVVM** with **dependency injection** throughout.
 - ❌ Subscribe to singleton events without unsubscribing — causes memory leaks
 - ❌ Mix cultures in number formatting — always use `InvariantCulture`
 - ❌ Use .NET 9 or older APIs/patterns — this is .NET 10
+- ❌ Leave review comments unaddressed or unreplied — complete the full review cycle atomically
+- ❌ Mark a task complete with pending review follow-ups — all comments must be replied to first
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Complete Architecture Refactor
 ### Added
+- Share functionality: share data file (JSON) and roast log (CSV) via OS share sheet
+- IShareService interface and ShareService implementation using MAUI Share API
+- Share Data File and Share Roast Log buttons on Settings page
+- Support for saving roasts without final weight (optional field for batch roasting workflows)
+- "Pending" roast level display for roasts awaiting final weight entry
+- HasFinalWeight and WeightLossDisplay computed properties on RoastData model
+- 8 new unit tests covering share commands and flexible roast saving
+
+### Changed
+- Bean quantity validation is now warning-only (no longer blocks timer start or saving)
+- Final weight field is now optional on the Roast page
+- Roast log displays "Pending" for weight loss and roast level when final weight is not yet entered
+- CSV export shows "Pending" for incomplete roasts instead of "0.0%"
+- RoastDataService handles Pending roast level for roasts without final weight
+- Version bumped to 1.2.0
+
+## [1.1.0] - Complete Architecture Refactor
+### Added
 - GitHub Actions CI workflow for automated build and test on PRs
 - Comprehensive README.md with architecture docs, build commands, and CI badge
 - Rewritten copilot-instructions.md reflecting new MVVM architecture and conventions

--- a/CafeMaestro.Tests/ViewModels/RoastPageViewModelTests.cs
+++ b/CafeMaestro.Tests/ViewModels/RoastPageViewModelTests.cs
@@ -217,6 +217,138 @@ public class RoastPageViewModelTests
         viewModel.CanMarkFirstCrack.Should().BeFalse();
     }
 
+    [Fact]
+    public async Task SaveCommand_InsufficientBeans_SavesSuccessfully()
+    {
+        BeanData bean = new()
+        {
+            Id = Guid.NewGuid(),
+            Country = "Colombia",
+            CoffeeName = "Supremo",
+            Variety = "Caturra",
+            RemainingQuantity = 0.05,
+            Quantity = 1
+        };
+        RoastData? savedRoast = null;
+
+        RoastPageViewModel viewModel = CreateViewModel(
+            setup: mocks =>
+            {
+                mocks.BeanDataService.Setup(service => service.GetSortedAvailableBeansAsync())
+                    .ReturnsAsync(new List<BeanData> { bean });
+                mocks.BeanDataService.Setup(service => service.UpdateBeanQuantityAsync(bean.Id, 0.1))
+                    .ReturnsAsync(true);
+                mocks.RoastDataService.Setup(service => service.SaveRoastDataAsync(It.IsAny<RoastData>()))
+                    .Callback<RoastData>(roast => savedRoast = roast)
+                    .ReturnsAsync(true);
+                mocks.RoastLevelService.Setup(service => service.GetRoastLevelNameAsync(15))
+                    .ReturnsAsync("City");
+            });
+
+        await viewModel.OnAppearingAsync();
+        viewModel.BatchWeightText = "100";
+        viewModel.FinalWeightText = "85";
+        viewModel.TemperatureText = "210";
+        viewModel.SetManualTimerDisplay("10:30");
+
+        await EventuallyAsync(() => viewModel.LossPercentLabel.Contains("15.0%"));
+        viewModel.IsBatchWeightWarningVisible.Should().BeTrue();
+        viewModel.CanStartTimer.Should().BeTrue();
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        savedRoast.Should().NotBeNull();
+        savedRoast!.BatchWeight.Should().Be(100);
+        savedRoast.FinalWeight.Should().Be(85);
+    }
+
+    [Fact]
+    public async Task SaveCommand_WithoutFinalWeight_SavesWithZeroFinalWeight()
+    {
+        BeanData bean = CreateBean();
+        RoastData? savedRoast = null;
+
+        RoastPageViewModel viewModel = CreateViewModel(
+            setup: mocks =>
+            {
+                mocks.BeanDataService.Setup(service => service.GetSortedAvailableBeansAsync())
+                    .ReturnsAsync(new List<BeanData> { bean });
+                mocks.BeanDataService.Setup(service => service.UpdateBeanQuantityAsync(bean.Id, 0.1))
+                    .ReturnsAsync(true);
+                mocks.RoastDataService.Setup(service => service.SaveRoastDataAsync(It.IsAny<RoastData>()))
+                    .Callback<RoastData>(roast => savedRoast = roast)
+                    .ReturnsAsync(true);
+            });
+
+        await viewModel.OnAppearingAsync();
+        viewModel.BatchWeightText = "100";
+        viewModel.TemperatureText = "210";
+        viewModel.SetManualTimerDisplay("10:30");
+        // FinalWeightText left empty
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        savedRoast.Should().NotBeNull();
+        savedRoast!.BatchWeight.Should().Be(100);
+        savedRoast.FinalWeight.Should().Be(0);
+    }
+
+    [Fact]
+    public void RoastData_PendingRoast_ShowsPendingLevel()
+    {
+        RoastData roast = new()
+        {
+            BeanType = "Ethiopia Yirgacheffe",
+            BatchWeight = 100,
+            FinalWeight = 0,
+            Temperature = 210,
+            RoastMinutes = 10,
+            RoastSeconds = 30,
+            RoastLevelName = "Pending"
+        };
+
+        roast.HasFinalWeight.Should().BeFalse();
+        roast.WeightLossPercentage.Should().Be(0);
+        roast.WeightLossDisplay.Should().Be("Pending");
+        roast.Summary.Should().Contain("Pending roast of");
+    }
+
+    [Fact]
+    public void RoastData_CompletedRoast_ShowsNormalLevel()
+    {
+        RoastData roast = new()
+        {
+            BeanType = "Ethiopia Yirgacheffe",
+            BatchWeight = 100,
+            FinalWeight = 85,
+            Temperature = 210,
+            RoastMinutes = 10,
+            RoastSeconds = 30,
+            RoastLevelName = "City"
+        };
+
+        roast.HasFinalWeight.Should().BeTrue();
+        roast.WeightLossPercentage.Should().Be(15);
+        roast.WeightLossDisplay.Should().Be("15.0%");
+        roast.Summary.Should().Contain("City roast of");
+    }
+
+    [Fact]
+    public void RoastData_ZeroFinalWeight_PassesValidation()
+    {
+        RoastData roast = new()
+        {
+            BeanType = "Ethiopia Yirgacheffe",
+            BatchWeight = 100,
+            FinalWeight = 0,
+            Temperature = 210,
+            RoastMinutes = 10,
+            RoastSeconds = 30
+        };
+
+        roast.Validate().Should().BeEmpty();
+    }
+
     private static BeanData CreateBean()
     {
         return new BeanData

--- a/CafeMaestro.Tests/ViewModels/SettingsPageViewModelTests.cs
+++ b/CafeMaestro.Tests/ViewModels/SettingsPageViewModelTests.cs
@@ -210,11 +210,92 @@ public class SettingsPageViewModelTests
         viewModel.RoastLevels.Last().Name.Should().Be("Burned");
     }
 
+    [Fact]
+    public async Task ShareDataFileCommand_SharesViaShareService()
+    {
+        var appDataService = CreateAppDataServiceMock();
+        var preferencesService = CreatePreferencesServiceMock();
+        var roastDataService = new Mock<IRoastDataService>();
+        var roastLevelService = CreateRoastLevelServiceMock([]);
+        var shareService = new Mock<IShareService>();
+
+        appDataService.SetupGet(service => service.DataFilePath).Returns(@"C:\data\cafemaestro.json");
+        shareService.Setup(service => service.ShareFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var viewModel = CreateViewModel(
+            appDataService.Object,
+            preferencesService.Object,
+            roastDataService.Object,
+            roastLevelService.Object,
+            shareService.Object);
+
+        await viewModel.ShareDataFileCommand.ExecuteAsync(null);
+
+        shareService.Verify(
+            service => service.ShareFileAsync(@"C:\data\cafemaestro.json", "Share CafeMaestro Data"),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ShareRoastLogCsvCommand_ExportsAndShares()
+    {
+        var appDataService = CreateAppDataServiceMock();
+        var preferencesService = CreatePreferencesServiceMock();
+        var roastDataService = new Mock<IRoastDataService>();
+        var roastLevelService = CreateRoastLevelServiceMock([]);
+        var shareService = new Mock<IShareService>();
+
+        roastDataService.Setup(service => service.ExportRoastLogAsync(It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+        shareService.Setup(service => service.ShareFileAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .Returns(Task.CompletedTask);
+
+        var viewModel = CreateViewModel(
+            appDataService.Object,
+            preferencesService.Object,
+            roastDataService.Object,
+            roastLevelService.Object,
+            shareService.Object);
+
+        await viewModel.ShareRoastLogCsvCommand.ExecuteAsync(null);
+
+        roastDataService.Verify(
+            service => service.ExportRoastLogAsync(It.Is<string>(path => path.Contains("CafeMaestro_RoastLog_") && path.EndsWith(".csv"))),
+            Times.Once);
+        shareService.Verify(
+            service => service.ShareFileAsync(It.IsAny<string>(), "Share Roast Log"),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ShareDataFileCommand_NoFile_ShowsError()
+    {
+        var appDataService = CreateAppDataServiceMock();
+        appDataService.SetupGet(service => service.DataFilePath).Returns(string.Empty);
+        var preferencesService = CreatePreferencesServiceMock();
+        var roastDataService = new Mock<IRoastDataService>();
+        var roastLevelService = CreateRoastLevelServiceMock([]);
+        var shareService = new Mock<IShareService>();
+
+        var viewModel = CreateViewModel(
+            appDataService.Object,
+            preferencesService.Object,
+            roastDataService.Object,
+            roastLevelService.Object,
+            shareService.Object);
+
+        await viewModel.ShareDataFileCommand.ExecuteAsync(null);
+
+        shareService.Verify(service => service.ShareFileAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
     private static SettingsPageViewModel CreateViewModel(
         IAppDataService appDataService,
         IPreferencesService preferencesService,
         IRoastDataService roastDataService,
-        IRoastLevelService roastLevelService)
+        IRoastLevelService roastLevelService,
+        IShareService? shareService = null)
     {
         return new SettingsPageViewModel(
             preferencesService,
@@ -224,6 +305,7 @@ public class SettingsPageViewModelTests
             Mock.Of<IFileSaver>(),
             Mock.Of<IFolderPicker>(),
             Mock.Of<INavigationService>(),
+            shareService ?? Mock.Of<IShareService>(),
             new WeakReferenceMessenger());
     }
 

--- a/CafeMaestro/CafeMaestro.csproj
+++ b/CafeMaestro/CafeMaestro.csproj
@@ -31,8 +31,8 @@
         <ApplicationId>cafemaestro</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>1.1.0</ApplicationDisplayVersion>
-        <ApplicationVersion>2</ApplicationVersion>
+        <ApplicationDisplayVersion>1.2.0</ApplicationDisplayVersion>
+        <ApplicationVersion>3</ApplicationVersion>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>

--- a/CafeMaestro/MauiProgram.cs
+++ b/CafeMaestro/MauiProgram.cs
@@ -37,6 +37,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IRoastLevelService, RoastLevelService>();
 		builder.Services.AddSingleton<INavigationService, NavigationService>();
 		builder.Services.AddSingleton<IAlertService, AlertService>();
+		builder.Services.AddSingleton<IShareService, ShareService>();
 		builder.Services.AddSingleton<IFileSaver>(FileSaver.Default);
 		builder.Services.AddSingleton<IFolderPicker>(FolderPicker.Default);
 

--- a/CafeMaestro/Models/RoastData.cs
+++ b/CafeMaestro/Models/RoastData.cs
@@ -23,7 +23,17 @@ namespace CafeMaestro.Models
         public int? FirstCrackSeconds { get; set; } = null;
 
         [JsonIgnore]
-        public double WeightLossPercentage => Math.Round(((BatchWeight - FinalWeight) / BatchWeight) * 100, 2);
+        public bool HasFinalWeight => FinalWeight > 0;
+
+        [JsonIgnore]
+        public double WeightLossPercentage => HasFinalWeight && BatchWeight > 0
+            ? Math.Round(((BatchWeight - FinalWeight) / BatchWeight) * 100, 2)
+            : 0;
+
+        [JsonIgnore]
+        public string WeightLossDisplay => HasFinalWeight
+            ? $"{WeightLossPercentage:F1}%"
+            : "Pending";
 
         [JsonIgnore]
         public string FormattedTime => $"{RoastMinutes:D2}:{RoastSeconds:D2}";
@@ -42,7 +52,9 @@ namespace CafeMaestro.Models
             : 0;
 
         [JsonIgnore]
-        public string Summary => $"{RoastLevelName} roast of {BeanType} at {Temperature}°C for {FormattedTime}";
+        public string Summary => HasFinalWeight
+            ? $"{RoastLevelName} roast of {BeanType} at {Temperature}°C for {FormattedTime}"
+            : $"Pending roast of {BeanType} at {Temperature}°C for {FormattedTime}";
 
         [JsonIgnore]
         public bool IsValid => !Validate().Any();

--- a/CafeMaestro/RoastLogPage.xaml
+++ b/CafeMaestro/RoastLogPage.xaml
@@ -167,7 +167,7 @@
                                                            Grid.ColumnSpan="2"
                                                            Spacing="15"
                                                            Margin="0,5,0,0">
-                                        <Label Text="{Binding WeightLossPercentage, StringFormat='Loss: {0:F1}%'}"
+                                        <Label Text="{Binding WeightLossDisplay, StringFormat='Loss: {0}'}"
                                                FontSize="14"
                                                TextColor="{DynamicResource ItemDetailTextColor}"/>
                                         <Label Text="{Binding FormattedTime, StringFormat='Time: {0}'}"

--- a/CafeMaestro/RoastPage.xaml
+++ b/CafeMaestro/RoastPage.xaml
@@ -225,7 +225,7 @@
                        TextColor="{StaticResource SwipeDeleteColor}"
                        FontAttributes="Bold"/>
 
-                <Label Text="Final Weight (g):"
+                <Label Text="Final Weight (g) - Optional:"
                        TextColor="{DynamicResource PrimaryTextColor}"/>
                 <Border Stroke="{DynamicResource EntryBorderColor}"
                         StrokeThickness="1"
@@ -233,7 +233,7 @@
                     <Entry x:Name="FinalWeightEntry"
                            Text="{Binding FinalWeightText, Mode=TwoWay}"
                            Keyboard="Numeric"
-                           Placeholder="Enter final weight"
+                           Placeholder="Enter final weight (or leave empty)"
                            TextColor="{DynamicResource PrimaryTextColor}"
                            BackgroundColor="{DynamicResource EntryBackgroundColor}"
                            PlaceholderColor="{DynamicResource PlaceholderColor}"/>

--- a/CafeMaestro/Services/Interfaces/IShareService.cs
+++ b/CafeMaestro/Services/Interfaces/IShareService.cs
@@ -1,0 +1,6 @@
+namespace CafeMaestro.Services;
+
+public interface IShareService
+{
+    Task ShareFileAsync(string filePath, string title);
+}

--- a/CafeMaestro/Services/RoastDataService.cs
+++ b/CafeMaestro/Services/RoastDataService.cs
@@ -196,7 +196,7 @@ namespace CafeMaestro.Services
                                   $"{roast.Temperature}," +
                                   $"{roast.BatchWeight}," +
                                   $"{roast.FinalWeight}," +
-                                  $"{(roast.HasFinalWeight ? roast.WeightLossPercentage.ToString("F1") : "")}," +
+                                  $"{(roast.HasFinalWeight ? roast.WeightLossPercentage.ToString("F1") : "Pending")}," +
                                   $"{roast.FormattedTime}," +
                                   $"{roast.RoastLevelName}," +
                                   $"\"{roast.Notes}\"");

--- a/CafeMaestro/Services/RoastDataService.cs
+++ b/CafeMaestro/Services/RoastDataService.cs
@@ -99,9 +99,16 @@ namespace CafeMaestro.Services
         {
             try
             {
-                // Before saving, determine and set the roast level name
-                string roastLevelName = await _roastLevelService.GetRoastLevelNameAsync(roastData.WeightLossPercentage);
-                roastData.RoastLevelName = roastLevelName;
+                // Before saving, determine and set the roast level name (only if final weight is known)
+                if (roastData.HasFinalWeight)
+                {
+                    string roastLevelName = await _roastLevelService.GetRoastLevelNameAsync(roastData.WeightLossPercentage);
+                    roastData.RoastLevelName = roastLevelName;
+                }
+                else
+                {
+                    roastData.RoastLevelName = "Pending";
+                }
 
                 // Load full app data
                 var appData = await _appDataService.LoadAppDataAsync();
@@ -133,10 +140,15 @@ namespace CafeMaestro.Services
 
                 foreach (var roastLog in appData.RoastLogs)
                 {
-                    if (string.IsNullOrEmpty(roastLog.RoastLevelName))
+                    if (string.IsNullOrEmpty(roastLog.RoastLevelName) && roastLog.HasFinalWeight)
                     {
                         // Use the RoastLevelService to get the correct level name
                         roastLog.RoastLevelName = await _roastLevelService.GetRoastLevelNameAsync(roastLog.WeightLossPercentage);
+                        needsUpdate = true;
+                    }
+                    else if (string.IsNullOrEmpty(roastLog.RoastLevelName) && !roastLog.HasFinalWeight)
+                    {
+                        roastLog.RoastLevelName = "Pending";
                         needsUpdate = true;
                     }
                 }
@@ -184,7 +196,7 @@ namespace CafeMaestro.Services
                                   $"{roast.Temperature}," +
                                   $"{roast.BatchWeight}," +
                                   $"{roast.FinalWeight}," +
-                                  $"{roast.WeightLossPercentage}," +
+                                  $"{(roast.HasFinalWeight ? roast.WeightLossPercentage.ToString("F1") : "")}," +
                                   $"{roast.FormattedTime}," +
                                   $"{roast.RoastLevelName}," +
                                   $"\"{roast.Notes}\"");
@@ -634,7 +646,14 @@ namespace CafeMaestro.Services
             try
             {
                 // Before saving, determine and set the roast level name
-                updatedRoast.RoastLevelName = await _roastLevelService.GetRoastLevelNameAsync(updatedRoast.WeightLossPercentage);
+                if (updatedRoast.HasFinalWeight)
+                {
+                    updatedRoast.RoastLevelName = await _roastLevelService.GetRoastLevelNameAsync(updatedRoast.WeightLossPercentage);
+                }
+                else
+                {
+                    updatedRoast.RoastLevelName = "Pending";
+                }
 
                 // Load full app data
                 var appData = await _appDataService.LoadAppDataAsync();

--- a/CafeMaestro/Services/ShareService.cs
+++ b/CafeMaestro/Services/ShareService.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-
 namespace CafeMaestro.Services;
 
 public class ShareService : IShareService

--- a/CafeMaestro/Services/ShareService.cs
+++ b/CafeMaestro/Services/ShareService.cs
@@ -1,0 +1,20 @@
+using System.Diagnostics;
+
+namespace CafeMaestro.Services;
+
+public class ShareService : IShareService
+{
+    public async Task ShareFileAsync(string filePath, string title)
+    {
+        if (!File.Exists(filePath))
+        {
+            throw new FileNotFoundException("The file to share was not found.", filePath);
+        }
+
+        await Share.Default.RequestAsync(new ShareFileRequest
+        {
+            Title = title,
+            File = new ShareFile(filePath)
+        });
+    }
+}

--- a/CafeMaestro/SettingsPage.xaml
+++ b/CafeMaestro/SettingsPage.xaml
@@ -121,6 +121,25 @@
                                                                      CornerRadius="25"/>
                                                  </HorizontalStackLayout>
 
+                                                 <HorizontalStackLayout Spacing="10"
+                                                                        HorizontalOptions="Center">
+                                                         <Button Text="Share Data File"
+                                                                 Command="{Binding ShareDataFileCommand}"
+                                                                 BackgroundColor="{DynamicResource SecondaryColor}"
+                                                                 TextColor="{DynamicResource ButtonTextColor}"
+                                                                 HeightRequest="48"
+                                                                 CornerRadius="24"
+                                                                 HorizontalOptions="FillAndExpand"/>
+
+                                                         <Button Text="Share Roast Log"
+                                                                 Command="{Binding ShareRoastLogCsvCommand}"
+                                                                 BackgroundColor="{DynamicResource SecondaryColor}"
+                                                                 TextColor="{DynamicResource ButtonTextColor}"
+                                                                 HeightRequest="48"
+                                                                 CornerRadius="24"
+                                                                 HorizontalOptions="FillAndExpand"/>
+                                                 </HorizontalStackLayout>
+
                                                  <Button Text="Use Default Location"
                                                          Command="{Binding UseDefaultDataFileCommand}"
                                                          BackgroundColor="{DynamicResource AccentColor}"

--- a/CafeMaestro/ViewModels/RoastPageViewModel.cs
+++ b/CafeMaestro/ViewModels/RoastPageViewModel.cs
@@ -621,7 +621,7 @@ public partial class RoastPageViewModel : ObservableObject, IQueryAttributable
         double finalWeight = 0;
         if (!string.IsNullOrWhiteSpace(FinalWeightText))
         {
-            if (!double.TryParse(FinalWeightText, out finalWeight) || finalWeight < 0)
+            if (!double.TryParse(FinalWeightText, out finalWeight) || finalWeight <= 0)
             {
                 await _alertService.ShowAlertAsync("Validation Error", "Please enter a valid final weight in grams.", "OK");
                 return null;

--- a/CafeMaestro/ViewModels/RoastPageViewModel.cs
+++ b/CafeMaestro/ViewModels/RoastPageViewModel.cs
@@ -568,7 +568,7 @@ public partial class RoastPageViewModel : ObservableObject, IQueryAttributable
             {
                 BatchWeightWarningText = $"Insufficient beans available! (only {availableBeans:F1} g remaining)";
                 IsBatchWeightWarningVisible = true;
-                CanStartTimer = false;
+                CanStartTimer = !IsTimerRunning;
                 return;
             }
         }
@@ -618,26 +618,20 @@ public partial class RoastPageViewModel : ObservableObject, IQueryAttributable
             return null;
         }
 
-        double batchWeightKg = batchWeight / 1000.0;
-        if (batchWeightKg > SelectedBean.RemainingQuantity)
+        double finalWeight = 0;
+        if (!string.IsNullOrWhiteSpace(FinalWeightText))
         {
-            await _alertService.ShowAlertAsync(
-                "Validation Error",
-                $"Not enough beans available. You have {SelectedBean.RemainingQuantity:F2}kg remaining, but need {batchWeightKg:F2}kg.",
-                "OK");
-            return null;
-        }
+            if (!double.TryParse(FinalWeightText, out finalWeight) || finalWeight < 0)
+            {
+                await _alertService.ShowAlertAsync("Validation Error", "Please enter a valid final weight in grams.", "OK");
+                return null;
+            }
 
-        if (!double.TryParse(FinalWeightText, out double finalWeight) || finalWeight <= 0)
-        {
-            await _alertService.ShowAlertAsync("Validation Error", "Please enter a valid final weight in grams.", "OK");
-            return null;
-        }
-
-        if (finalWeight > batchWeight)
-        {
-            await _alertService.ShowAlertAsync("Validation Error", "Final weight cannot be greater than batch weight.", "OK");
-            return null;
+            if (finalWeight > batchWeight)
+            {
+                await _alertService.ShowAlertAsync("Validation Error", "Final weight cannot be greater than batch weight.", "OK");
+                return null;
+            }
         }
 
         if (!double.TryParse(TemperatureText, out double temperature) || temperature <= 0)
@@ -704,7 +698,9 @@ public partial class RoastPageViewModel : ObservableObject, IQueryAttributable
 
             TimerDisplay = FormatTime(_roastToEdit.RoastMinutes, _roastToEdit.RoastSeconds);
             BatchWeightText = _roastToEdit.BatchWeight.ToString("F1");
-            FinalWeightText = _roastToEdit.FinalWeight.ToString("F1");
+            FinalWeightText = _roastToEdit.HasFinalWeight
+                ? _roastToEdit.FinalWeight.ToString("F1")
+                : string.Empty;
             TemperatureText = _roastToEdit.Temperature.ToString("F0");
             Notes = _roastToEdit.Notes;
 

--- a/CafeMaestro/ViewModels/SettingsPageViewModel.cs
+++ b/CafeMaestro/ViewModels/SettingsPageViewModel.cs
@@ -22,6 +22,7 @@ public partial class SettingsPageViewModel : ObservableObject
     private readonly IFileSaver _fileSaver;
     private readonly IFolderPicker _folderPicker;
     private readonly INavigationService _navigationService;
+    private readonly IShareService _shareService;
     private readonly IMessenger _messenger;
     private bool _isLoadingThemeSettings;
     private bool _isThemeInitialized;
@@ -37,7 +38,8 @@ public partial class SettingsPageViewModel : ObservableObject
         IRoastLevelService roastLevelService,
         IFileSaver fileSaver,
         IFolderPicker folderPicker,
-        INavigationService navigationService)
+        INavigationService navigationService,
+        IShareService shareService)
         : this(
             preferencesService,
             appDataService,
@@ -46,6 +48,7 @@ public partial class SettingsPageViewModel : ObservableObject
             fileSaver,
             folderPicker,
             navigationService,
+            shareService,
             WeakReferenceMessenger.Default)
     {
     }
@@ -58,6 +61,7 @@ public partial class SettingsPageViewModel : ObservableObject
         IFileSaver fileSaver,
         IFolderPicker folderPicker,
         INavigationService navigationService,
+        IShareService shareService,
         IMessenger messenger)
     {
         _preferencesService = preferencesService ?? throw new ArgumentNullException(nameof(preferencesService));
@@ -67,6 +71,7 @@ public partial class SettingsPageViewModel : ObservableObject
         _fileSaver = fileSaver ?? throw new ArgumentNullException(nameof(fileSaver));
         _folderPicker = folderPicker ?? throw new ArgumentNullException(nameof(folderPicker));
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+        _shareService = shareService ?? throw new ArgumentNullException(nameof(shareService));
         _messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
     }
 
@@ -323,6 +328,48 @@ public partial class SettingsPageViewModel : ObservableObject
         {
             Debug.WriteLine($"Error exporting roast log: {ex.Message}");
             SendAlert("Error", $"Failed to export data: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    public async Task ShareDataFileAsync()
+    {
+        try
+        {
+            string filePath = _appDataService.DataFilePath;
+            if (string.IsNullOrWhiteSpace(filePath))
+            {
+                SendAlert("Error", "No data file found to share. Please create or select a data file first.");
+                return;
+            }
+
+            await _shareService.ShareFileAsync(filePath, "Share CafeMaestro Data");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error sharing data file: {ex.Message}");
+            SendAlert("Error", $"Failed to share data file: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    public async Task ShareRoastLogCsvAsync()
+    {
+        try
+        {
+            string tempDir = Path.Combine(Path.GetTempPath(), "CafeMaestro");
+            Directory.CreateDirectory(tempDir);
+
+            string fileName = $"CafeMaestro_RoastLog_{DateTime.Now:yyyy-MM-dd}.csv";
+            string tempFilePath = Path.Combine(tempDir, fileName);
+
+            await _roastDataService.ExportRoastLogAsync(tempFilePath);
+            await _shareService.ShareFileAsync(tempFilePath, "Share Roast Log");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Error sharing roast log: {ex.Message}");
+            SendAlert("Error", $"Failed to share roast log: {ex.Message}");
         }
     }
 


### PR DESCRIPTION
## Summary

Two usability improvements for coffee roasting workflows:

### Feature A: Share Functionality
- Share Data File - shares the JSON backup via OS share sheet (OneDrive, WhatsApp, etc.)
- Share Roast Log (CSV) - generates a temp CSV export and shares it
- New IShareService/ShareService using MAUI Share.RequestAsync()
- Two share buttons added to Settings page

### Feature B: Flexible Roast Saving
- Bean quantity check changed from hard block to warning-only (timer + save still allowed)
- Final weight now optional - can save with empty final weight for batch roasting
- Incomplete roasts show Pending for roast level and weight loss
- Editing a pending roast shows empty final weight field

### Testing
- 96 tests passing (88 existing + 8 new)
- Builds clean for Windows and Android
- Code reviewed by Claude Sonnet 4.6 - both findings addressed
- Version bumped to 1.2.0
